### PR TITLE
10 create clang tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,3 @@
 Checks: "-*,clang-analyzer-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,cert-*,bugprone-*,misc-*,fuchsia-*"
 WarningsAsErrors: "-*,clang-analyzer-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,cert-*,bugprone-*,misc-*,fuchsia-*"
+HeaderFilter: ".*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: "-*,clang-analyzer-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,cert-*,bugprone-*,misc-*,fuchsia-*"
+WarningsAsErrors: "-*,clang-analyzer-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,cert-*,bugprone-*,misc-*,fuchsia-*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,2 @@
 Checks: "-*,clang-analyzer-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,cert-*,bugprone-*,misc-*,fuchsia-*"
 WarningsAsErrors: "-*,clang-analyzer-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,cert-*,bugprone-*,misc-*,fuchsia-*"
-HeaderFilter: ".*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ script:
   - export CC=gcc-7
   - export CXX=g++-7
   - mkdir build && cd build
-  - cmake ..
-  - make tester && ./semseterser_test
-  - make
+  - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+  - make && ./semseterser_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(semseterser)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 file(GLOB semseterser_src
     RELATIVE ${PROJECT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,14 @@ project(semseterser)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 file(GLOB semseterser_src
     RELATIVE ${PROJECT_SOURCE_DIR}
     "src/main.cpp"
     "src/game/*.cpp"
 )
+
+set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 # Executable name to be built
 add_executable(semseterser ${semseterser_src})
@@ -22,6 +23,8 @@ if(MSVC)
 else()
     target_compile_options(semseterser PRIVATE -Wall -Wextra -Wpedantic -O2)
 endif()
+
+unset(CMAKE_CXX_CLANG_TIDY)
 
 # Enable running ctest
 enable_testing()

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -14,7 +14,7 @@ void semseterser::Game::start()
   chrono::time_point<chrono::steady_clock>    current,
                               previous = chrono::steady_clock::now();
 
-  chrono::duration<int64_t, std::nano> elapsed;
+  chrono::duration<int64_t, std::nano> elapsed{};
 
   int64_t     lag = 0.0;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -10,13 +10,13 @@ semseterser::Game::Game(int64_t updatesPerSecond)
 
 void semseterser::Game::start()
 {
-  int64_t nsPerUpdate = 1.0 / this->updatesPerSec * 1000000;
+  int64_t nsPerUpdate = this->updatesPerSec / 1000000;
   chrono::time_point<chrono::steady_clock>    current,
                               previous = chrono::steady_clock::now();
 
   chrono::duration<int64_t, std::nano> elapsed{};
 
-  int64_t     lag = 0.0;
+  int64_t     lag = 0;
 
   while (true) {
       current = chrono::steady_clock::now();

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -1,5 +1,5 @@
-#ifndef GAME_HPP
-#define GAME_HPP
+#ifndef SEMSETERSER_GAME_HPP
+#define SEMSETERSER_GAME_HPP
 
 #include <chrono>
 
@@ -10,9 +10,9 @@ namespace semseterser {
 
     public:
       Game();
-      Game(int64_t updatesPerSecond);
+      explicit Game(int64_t updatesPerSecond);
       void start();
   };
-}
+}  // namespace semseterser
 
-#endif /* GAME_HPP */
+#endif /* SEMSETERSER_GAME_HPP */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-  semseterser::Game* game = new semseterser::Game();
+  auto game = new semseterser::Game();
   game->start();
 
   return 0;


### PR DESCRIPTION
Clang tidy works.

Needs clang and clang-tidy installed locally to work.

To test this branch:
1. install clang and clang-tidy
1. `mkdir build && cd build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..`
1. `make` (should succeed without errors)

After this, you can e.g. change from `main.cpp` the line
```cpp
auto game = new semseterser::Game();
```
to
```cpp
semseterser::Game* game = new semseterser::Game();
```
and then run `make` again. The build should now fail.