### PR TITLE
Add SFML to Cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(semseterser)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(PROJECT_TESTER_NAME ${PROJECT_NAME}_test)
 
 file(GLOB semseterser_src
     RELATIVE ${PROJECT_SOURCE_DIR}
@@ -13,20 +14,24 @@ file(GLOB semseterser_src
 )
 
 # Executable name to be built
-add_executable(semseterser ${semseterser_src})
+add_executable(${PROJECT_NAME} ${semseterser_src})
 
 # Compiler options per platform
 if(MSVC)
-    target_compile_options(semseterser PRIVATE /W4 -O2)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W4 -O2)
 else()
-    target_compile_options(semseterser PRIVATE -Wall -Wextra -Wpedantic -O2)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -O2)
 endif()
+
+include(GNUInstallDirs)
+
+# Enable downloading external projects during build
+include(ExternalProject)
 
 # Enable running ctest
 enable_testing()
 
 # Add googletest. Will be downloaded from git.
-include(ExternalProject)
 ExternalProject_Add(
     googletest
     GIT_REPOSITORY "https://github.com/google/googletest.git"
@@ -34,16 +39,11 @@ ExternalProject_Add(
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/googletest
 )
 
-# Exclude googletest building from target "all"
-set_target_properties(googletest PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-include(GNUInstallDirs)
+# Required for googletest
+find_package(Threads REQUIRED)
 
 link_directories(${CMAKE_BINARY_DIR}/googletest/${CMAKE_INSTALL_LIBDIR})
 include_directories(${CMAKE_BINARY_DIR}/googletest/${CMAKE_INSTALL_INCLUDEDIR})
-
-# Required for googletest
-find_package(Threads REQUIRED)
 
 # Use all .cpp files in the test folder
 file(GLOB_RECURSE TEST_SOURCES
@@ -51,10 +51,14 @@ file(GLOB_RECURSE TEST_SOURCES
     CONFIGURE_DEPENDS
     src/test/*.cpp)
 
-set(PROJECT_TESTER_NAME ${PROJECT_NAME}_test)
 add_executable(${PROJECT_TESTER_NAME} ${TEST_SOURCES})
 add_dependencies(${PROJECT_TESTER_NAME} googletest)
-target_link_libraries(${PROJECT_TESTER_NAME} gtest gtest_main Threads::Threads)
+target_link_libraries(
+    ${PROJECT_TESTER_NAME}
+    gtest
+    gtest_main
+    Threads::Threads
+)
 
 add_test(${PROJECT_TESTER_NAME} ${PROJECT_TESTER_NAME})
 
@@ -62,3 +66,22 @@ add_test(${PROJECT_TESTER_NAME} ${PROJECT_TESTER_NAME})
 add_custom_target(tester
     COMMAND ${PROJECT_TESTER_NAME} || true # suppress verbose errors
     DEPENDS ${PROJECT_TESTER_NAME})
+
+# Exclude googletest building from target "all"
+set_target_properties(googletest PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+# Add SFML
+ExternalProject_Add(
+    sfml
+    GIT_REPOSITORY "https://github.com/SFML/SFML.git"
+    GIT_TAG "2.5.1"
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/sfml
+)
+
+find_package(SFML 2.5.1 COMPONENTS graphics REQUIRED)
+set(SFML_STATIC_LIBRARIES TRUE)
+
+target_link_libraries(
+    ${PROJECT_NAME}
+    sfml-graphics
+)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Semseterser
 
 [![Build Status](https://travis-ci.org/Semseterser/Semseterser.svg?branch=master)](https://travis-ci.org/Semseterser/Semseterser)
+
+## Development
+To build the project:
+```bash
+git clone https://github.com/Semseterser/Semseterser.git
+cd Semseterser
+mkdir build
+cmake .. && make
+```
+In order to keep the development of semseterser as consistent as possible,
+some of the core libraries are fetched and compiled automatically during the
+build phase. See [Dependencies](#Dependencies) to find out requirements for building
+the libraries.
+
+## Dependencies
+
+For SFML:
+* pthread
+* opengl
+* xlib
+* xrandr
+* udev
+* freetype
+* openal
+* flac
+* vorbis
+
+In case of a build failure, check [the SFML website](https://www.sfml-dev.org/faq.php#grl-dependencies) for any missing dependencies.


### PR DESCRIPTION
SFML is now downloaded and compiled during the build of the project. I also re-ordered `CMakeLists.txt` in an attempt to make it more sensible.

I tested drawing a SFML::Window in the main function, but excluded it from this PR as #8 will handle that.